### PR TITLE
add boss flip

### DIFF
--- a/src/config/card.cairo
+++ b/src/config/card.cairo
@@ -1,3 +1,5 @@
+use card_knight::models::card::CardIdEnum;
+
 // Monsters
 const MONSTER1_BASE_HP: u32 = 5;
 const MONSTER1_MULTIPLE: u32 = 2;
@@ -27,3 +29,32 @@ const CHEST_XP: u32 = 1;
 
 // Tags
 const INCREASE_HP_RATIO: u32 = 20; // %20
+
+
+fn card_sequence() -> Array::<CardIdEnum> {
+    let mut card_sequence = ArrayTrait::<CardIdEnum>::new();
+    card_sequence.append(CardIdEnum::Monster1);
+    card_sequence.append(CardIdEnum::ItemHeal);
+    card_sequence.append(CardIdEnum::Monster2);
+    card_sequence.append(CardIdEnum::ItemPoison);
+    card_sequence.append(CardIdEnum::Monster3);
+    card_sequence.append(CardIdEnum::ItemChest);
+    card_sequence.append(CardIdEnum::Monster1);
+    card_sequence.append(CardIdEnum::ItemHeal);
+    card_sequence.append(CardIdEnum::Monster2);
+    card_sequence.append(CardIdEnum::ItemChestMiniGame);
+    card_sequence.append(CardIdEnum::Monster3);
+    card_sequence.append(CardIdEnum::ItemChestEvil);
+    card_sequence.append(CardIdEnum::Monster1);
+    card_sequence.append(CardIdEnum::ItemShield);
+    card_sequence.append(CardIdEnum::Monster2);
+    card_sequence.append(CardIdEnum::Boss1);
+    card_sequence.append(CardIdEnum::ItemChestEvil);
+    card_sequence.append(CardIdEnum::Monster1);
+    card_sequence.append(CardIdEnum::ItemHeal);
+    card_sequence.append(CardIdEnum::Monster2);
+    card_sequence.append(CardIdEnum::ItemChestMiniGame);
+    card_sequence.append(CardIdEnum::Monster3);
+    card_sequence.append(CardIdEnum::ItemChestEvil);
+    card_sequence
+}

--- a/src/models/card.cairo
+++ b/src/models/card.cairo
@@ -7,7 +7,7 @@ use dojo::world::{IWorld, IWorldDispatcher, IWorldDispatcherTrait};
 use card_knight::config::card::{
     MONSTER1_BASE_HP, MONSTER1_MULTIPLE, MONSTER2_BASE_HP, MONSTER2_MULTIPLE, MONSTER3_BASE_HP,
     MONSTER3_MULTIPLE, MONSTER1_XP, MONSTER2_XP, MONSTER3_XP, BOSS_XP, HEAL_XP, POISON_XP,
-    SHIELD_XP, CHEST_XP, POISON_TURN, INCREASE_HP_RATIO
+    SHIELD_XP, CHEST_XP, POISON_TURN, INCREASE_HP_RATIO, card_sequence
 };
 use card_knight::config::map::{MAP_RANGE};
 use card_knight::utils::random_index;
@@ -367,30 +367,7 @@ impl ICardImpl of ICardTrait {
     }
 
     fn spawn_card(world: IWorldDispatcher, game_id: u32, x: u32, y: u32, player: Player) {
-        let mut card_sequence = ArrayTrait::new();
-        card_sequence.append(CardIdEnum::Monster1);
-        card_sequence.append(CardIdEnum::ItemHeal);
-        card_sequence.append(CardIdEnum::Monster2);
-        card_sequence.append(CardIdEnum::ItemPoison);
-        card_sequence.append(CardIdEnum::Monster3);
-        card_sequence.append(CardIdEnum::ItemChest);
-        card_sequence.append(CardIdEnum::Monster1);
-        card_sequence.append(CardIdEnum::ItemHeal);
-        card_sequence.append(CardIdEnum::Monster2);
-        card_sequence.append(CardIdEnum::ItemChestMiniGame);
-        card_sequence.append(CardIdEnum::Monster3);
-        card_sequence.append(CardIdEnum::ItemChestEvil);
-        card_sequence.append(CardIdEnum::Monster1);
-        card_sequence.append(CardIdEnum::ItemShield);
-        card_sequence.append(CardIdEnum::Monster2);
-        card_sequence.append(CardIdEnum::Boss1);
-        card_sequence.append(CardIdEnum::ItemChestEvil);
-        card_sequence.append(CardIdEnum::Monster1);
-        card_sequence.append(CardIdEnum::ItemHeal);
-        card_sequence.append(CardIdEnum::Monster2);
-        card_sequence.append(CardIdEnum::ItemChestMiniGame);
-        card_sequence.append(CardIdEnum::Monster3);
-        card_sequence.append(CardIdEnum::ItemChestEvil);
+        let mut card_sequence = card_sequence();
         let mut sequence = player.sequence;
         if sequence >= card_sequence.len() {
             sequence = 0;

--- a/src/models/card.cairo
+++ b/src/models/card.cairo
@@ -27,7 +27,8 @@ struct Card {
     shield: u32,
     max_shield: u32,
     xp: u32,
-    tag: TagType
+    tag: TagType,
+    flipped: bool
 }
 
 #[derive(Drop, Serde)]
@@ -64,6 +65,7 @@ impl ICardImpl of ICardTrait {
                 let damage = card.hp + card.shield;
                 player.take_damage(damage);
                 player.add_exp(BOSS_XP);
+                Self::flip_cards(world, player.game_id, true);
                 return player;
             },
             CardIdEnum::ItemHeal => {
@@ -96,7 +98,8 @@ impl ICardImpl of ICardTrait {
                         shield: 0,
                         max_shield: 0,
                         xp: HEAL_XP,
-                        tag: TagType::None
+                        tag: TagType::None,
+                        flipped: false,
                     };
                     set!(world, (new_card));
                 } else if (index == 1) {
@@ -111,7 +114,8 @@ impl ICardImpl of ICardTrait {
                         shield: 0,
                         max_shield: 0,
                         xp: POISON_XP,
-                        tag: TagType::None
+                        tag: TagType::None,
+                        flipped: false,
                     };
                     set!(world, (new_card));
                 } else if (index == 2) {
@@ -126,7 +130,8 @@ impl ICardImpl of ICardTrait {
                         shield: card_value,
                         max_shield: 0,
                         xp: SHIELD_XP,
-                        tag: TagType::None
+                        tag: TagType::None,
+                        flipped: false,
                     };
                     set!(world, (new_card));
                 }
@@ -366,7 +371,9 @@ impl ICardImpl of ICardTrait {
         *(neighbour_cards.at(index))
     }
 
-    fn spawn_card(world: IWorldDispatcher, game_id: u32, x: u32, y: u32, player: Player) {
+    fn spawn_card(
+        world: IWorldDispatcher, game_id: u32, x: u32, y: u32, player: Player
+    ) -> (Card, bool) {
         let mut card_sequence = ArrayTrait::new();
         card_sequence.append(CardIdEnum::Monster1);
         card_sequence.append(CardIdEnum::ItemHeal);
@@ -398,6 +405,7 @@ impl ICardImpl of ICardTrait {
         let card_id = card_sequence.at(sequence);
         let mut new_player = player;
         new_player.sequence = sequence + 1;
+
         set!(world, (new_player));
         let max_hp = {
             match card_id {
@@ -444,10 +452,59 @@ impl ICardImpl of ICardTrait {
             shield: 0,
             max_shield: 0,
             xp: xp,
-            tag: tag_type
+            tag: tag_type,
+            flipped: false,
         };
         set!(world, (card));
+        let is_boss = if (card.card_id == CardIdEnum::Boss1) {
+            true
+        } else {
+            false
+        };
+        if (is_boss) {
+            Self::flip_cards(world, game_id, true);
+        }
+
+        return (card, is_boss);
     }
+
+
+    fn flip_cards(world: IWorldDispatcher, game_id: u32, flip: bool) {
+        let mut x: u32 = 0;
+        let mut y: u32 = 0;
+        while x <= MAP_RANGE {
+            while y <= MAP_RANGE {
+                let mut card = get!(world, (game_id, x, y), (Card));
+                if (card.card_id != CardIdEnum::Boss1 && card.card_id != CardIdEnum::Player) {
+                    card.flipped = flip;
+                    set!(world, (card));
+                }
+
+                y = y + 1;
+            };
+            x = x + 1;
+        };
+    }
+
+
+    fn is_boss_active(world: IWorldDispatcher, game_id: u32, flip: bool) -> bool {
+        let mut is_active = false;
+        let mut x: u32 = 0;
+        let mut y: u32 = 0;
+        while x <= MAP_RANGE {
+            while y <= MAP_RANGE {
+                let mut card = get!(world, (game_id, x, y), (Card));
+                if (card.card_id == CardIdEnum::Boss1) {
+                    is_active = true;
+                    break;
+                }
+                y = y + 1;
+            };
+            x = x + 1;
+        };
+        is_active
+    }
+
 
     fn get_tag(card_id: CardIdEnum, x: u32, y: u32) -> TagType {
         let is_monster = match card_id {

--- a/src/models/skill.cairo
+++ b/src/models/skill.cairo
@@ -62,6 +62,9 @@ impl IPlayerSkillImpl of IPlayerSkill {
                     if (card.is_monster() && card.tag != TagType::NoMagic) {
                         card.hp -= card.hp / 4;
                         if (card.hp == 0) {
+                            if (card.card_id == CardIdEnum::Boss1) {
+                                ICardImpl::flip_cards(world, player.game_id, false);
+                            }
                             ICardImpl::spawn_card(world, player.game_id, card.x, card.y, player);
                         } else {
                             set!(world, (card));
@@ -86,6 +89,9 @@ impl IPlayerSkillImpl of IPlayerSkill {
                 if (card.is_monster() && card.tag != TagType::NoMagic) {
                     let damage = card.max_hp / 4 + 1;
                     if (card.hp <= damage) {
+                        if (card.card_id == CardIdEnum::Boss1) {
+                            ICardImpl::flip_cards(world, player.game_id, false);
+                        }
                         ICardImpl::spawn_card(world, player.game_id, card.x, card.y, player);
                     } else {
                         card.hp = card.hp - damage;
@@ -104,6 +110,9 @@ impl IPlayerSkillImpl of IPlayerSkill {
                     let mut card = get!(world, (player.game_id, x, y), (Card));
                     if (card.is_monster() && card.tag != TagType::NoMagic) {
                         if (card.hp < damage) {
+                            if (card.card_id == CardIdEnum::Boss1) {
+                                ICardImpl::flip_cards(world, player.game_id, false);
+                            }
                             ICardImpl::spawn_card(world, player.game_id, card.x, card.y, player);
                         } else {
                             card.hp -= damage;
@@ -142,7 +151,8 @@ impl IPlayerSkillImpl of IPlayerSkill {
                     shield: 0,
                     max_shield: 0,
                     xp: 0,
-                    tag: TagType::None
+                    tag: TagType::None,
+                    flipped: false,
                 };
                 set!(world, (new_card));
             }

--- a/src/systems/actions.cairo
+++ b/src/systems/actions.cairo
@@ -20,7 +20,7 @@ mod actions {
     use starknet::{ContractAddress, get_caller_address};
     use card_knight::models::{
         game::{Game, Direction, GameState, TagType},
-        card::{Card, CardIdEnum, ICardImpl, ICardTrait}, player::{Player, IPlayer, Hero}
+        card::{Card, CardIdEnum, ICardImpl, ICardTrait,}, player::{Player, IPlayer, Hero}
     };
     use card_knight::models::skill::{Skill, PlayerSkill, IPlayerSkill};
     use card_knight::models::game::{apply_tag_effects, is_silent};
@@ -75,7 +75,8 @@ mod actions {
                                     shield: 0,
                                     max_shield: 10,
                                     xp: 0,
-                                    tag: TagType::None
+                                    tag: TagType::None,
+                                    flipped: false,
                                 },
                             )
                         );
@@ -120,7 +121,8 @@ mod actions {
                                 shield: 0,
                                 max_shield: 0,
                                 xp: MONSTER1_XP,
-                                tag: TagType::None
+                                tag: TagType::None,
+                                flipped: false,
                             })
                         );
                         MONSTER_COUNT -= 1;
@@ -137,7 +139,8 @@ mod actions {
                                 shield: 0,
                                 max_shield: 0,
                                 xp: HEAL_XP,
-                                tag: TagType::None
+                                tag: TagType::None,
+                                flipped: false,
                             })
                         );
                         ITEM_COUNT -= 1;
@@ -154,6 +157,7 @@ mod actions {
         fn move(ref world: IWorldDispatcher, game_id: u32, direction: Direction) {
             let player_address = get_caller_address();
             let mut player = get!(world, (game_id, player_address), (Player));
+            assert(player.hp != 0, 'Player is dead');
             let old_player_card = get!(world, (game_id, player.x, player.y), (Card));
             // delete!(world, (old_player_card));
             let (next_x, next_y) = match direction {
@@ -204,7 +208,8 @@ mod actions {
                 shield: player.shield,
                 max_shield: player.max_shield,
                 xp: 0,
-                tag: TagType::None
+                tag: TagType::None,
+                flipped: false,
             };
 
             // Move cards after use
@@ -291,6 +296,8 @@ mod actions {
         ) {
             let player_address = get_caller_address();
             let mut player = get!(world, (game_id, player_address), (Player));
+            assert(player.hp != 0, 'Player is dead');
+
             player.validate_skill(skill);
             let mut player_skill = get!(world, (game_id, player_address, skill), (PlayerSkill));
             assert(!is_silent(world, player), 'Silence active');
@@ -331,8 +338,11 @@ mod actions {
 
         fn use_curse_skill(ref world: IWorldDispatcher, game_id: u32, x: u32, y: u32) {
             let player_address = get_caller_address();
+
             let skill = Skill::Curse;
             let mut player = get!(world, (game_id, player_address), (Player));
+            assert(player.hp != 0, 'Player is dead');
+
             player.validate_skill(skill);
 
             let mut player_skill = get!(world, (game_id, player_address, skill), (PlayerSkill));
@@ -349,6 +359,7 @@ mod actions {
         fn level_up(ref world: IWorldDispatcher, game_id: u32, upgrade: u32) {
             let player_address = get_caller_address();
             let mut player = get!(world, (game_id, player_address), (Player));
+            assert(player.hp != 0, 'Player is dead');
             player.level_up(upgrade);
         }
     }


### PR DESCRIPTION
fixes #3 

Added flipped value to card struct. When boss spawned all card will be flipped except payer and boss
struct Card {
    #[key]
    game_id: u32,
    #[key]
    x: u32,
    #[key]
    y: u32,
    card_id: CardIdEnum,
    hp: u32,
    max_hp: u32,
    shield: u32,
    max_shield: u32,
    xp: u32,
    tag: TagType,
    flipped: bool
}
